### PR TITLE
Tarefa: Remove binário e adiciona .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Executables
+*.exe
+*.out
+*.app
+app
+
+# Go build artifacts
+bin/
+dist/
+
+# OS files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.exe
 *.out
 *.app
-app
 
 # Go build artifacts
 bin/


### PR DESCRIPTION
## O que foi feito
- Remoção do executável compilado do repositório.
- Adição do arquivo. gitignore para impedir o commit de binários e artefatos de compilação.

## Por que foi feito 
Arquivos executáveis são gerados durante o processo de compilação e não devem ser rastreados no controle de versão.

Esse aprendizado me ensina a manter o repositório limpo e alinhado com as melhores práticas.

## Observações
Não houve alteração funcional na lógica de monitoramento.